### PR TITLE
[Lab4 Part B]: Key/value service without snapshots 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,16 @@
 
     - **[Lab4A Code Change](https://github.com/mwfj/6.5840-Distributed-Systems/pull/13)**
 
-  - [ ] Part B: Key/value service without snapshots: Now you will use the `rsm` package to replicate a key/value server. Each of the servers ("kvservers") will have an associated rsm/Raft peer. Clerks send `Put()` and `Get()` RPCs to the kvserver whose associated Raft is the leader. The kvserver code submits the Put/Get operation to `rsm`, which replicates it using Raft and invokes your server's `DoOp` at each peer, which should apply the operations to the peer's key/value database; the intent is for the servers to maintain identical replicas of the key/value database.
+  - [x] Part B: Key/value service without snapshots: Now you will use the `rsm` package to replicate a key/value server. Each of the servers ("kvservers") will have an associated rsm/Raft peer. Clerks send `Put()` and `Get()` RPCs to the kvserver whose associated Raft is the leader. The kvserver code submits the Put/Get operation to `rsm`, which replicates it using Raft and invokes your server's `DoOp` at each peer, which should apply the operations to the peer's key/value database; the intent is for the servers to maintain identical replicas of the key/value database.
 
     A `Clerk` sometimes doesn't know which kvserver is the Raft leader. If the `Clerk` sends an RPC to the wrong kvserver, or if it cannot reach the kvserver, the `Clerk` should re-try by sending to a different kvserver. If the key/value service commits the operation to its Raft log (and hence applies the operation to the key/value state machine), the leader reports the result to the `Clerk` by responding to its RPC. If the operation failed to commit (for example, if the leader was replaced), the server reports an error, and the `Clerk` retries with a different server.
 
     Your kvservers should not directly communicate; they should only interact with each other through Raft.
 
-  - [ ] Part C: Key/value service with snapshots:  As things stand now, your key/value server doesn't call your Raft library's `Snapshot()` method, so a rebooting server has to replay the complete persisted Raft log in order to restore its state. Now you'll modify kvserver and `rsm` to cooperate with Raft to save log space and reduce restart time, using Raft's `Snapshot()` from Lab 3D.
+    - [Lab 4B code change](https://github.com/mwfj/6.5840-Distributed-Systems/pull/15)
 
+  - [ ] Part C: Key/value service with snapshots:  As things stand now, your key/value server doesn't call your Raft library's `Snapshot()` method, so a rebooting server has to replay the complete persisted Raft log in order to restore its state. Now you'll modify kvserver and `rsm` to cooperate with Raft to save log space and reduce restart time, using Raft's `Snapshot()` from Lab 3D.
+  
     The tester passes `maxraftstate` to your `StartKVServer()`, which passes it to `rsm`. `maxraftstate` indicates the maximum allowed size of your persistent Raft state in bytes (including the log, but not including snapshots). You should compare `maxraftstate` to `rf.PersistBytes()`. Whenever your `rsm` detects that the Raft state size is approaching this threshold, it should save a snapshot by calling Raft's `Snapshot`. `rsm` can create this snapshot by calling the `Snapshot` method of the `StateMachine` interface to obtain a snapshot of the kvserver. If `maxraftstate` is -1, you do not have to snapshot. The `maxraftstate` limit applies to the GOB-encoded bytes your Raft passes as the first argument to `persister.Save()`.
   
     You can find the source for the `persister` object in `tester1/persister.go`.

--- a/src/kvraft1/client.go
+++ b/src/kvraft1/client.go
@@ -45,7 +45,11 @@ func (ck *Clerk) Get(key string) (string, rpc.Tversion, rpc.Err) {
 	// You will have to modify this function.
 	ck.seqNum++
 	var reply rpc.GetReply
-	args := rpc.GetArgs{Key: key}
+	args := rpc.GetArgs{
+		Key:      key,
+		SeqNum:   ck.seqNum,
+		ClientId: ck.clientId,
+	}
 
 	for {
 		reply = rpc.GetReply{}

--- a/src/raft1/README.md
+++ b/src/raft1/README.md
@@ -61,7 +61,7 @@ Implement Snapshot(Log compact) in Raft.
 - Careful conflict resolution maintains log consistency
 - Persistence before RPC reply ensures crash safety
 
-![lab3b-log](https://raw.githubusercontent.com/mwfj/6.5840-Distributed-Systems/refs/heads/master/src/raft/pics/6-5840-raft-lab-3d-snapshot.svg)
+![lab3b-log](https://raw.githubusercontent.com/mwfj/6.5840-Distributed-Systems/refs/heads/master/src/raft1/pics/6-5840-raft-lab-3d-snapshot.svg)
 
 ## Test Result
 


### PR DESCRIPTION
- Implement `Get` method in Replicated State Machine
- Implement `Put` method in Replicated State Machine
- Implement `DoOp` method in Replicated State Machine

The code has pass all of 4B test

```shell
~ go test -run 4B -race
Test: one client (4B basic) (reliable network)...
labgob warning: Decoding into a non-default variable/field Err may not work
  ... Passed --  time  3.1s #peers 5 #RPCs  2888 #Ops  511
Test: one client (4B speed) (reliable network)...
  ... Passed --  time  9.9s #peers 3 #RPCs  3437 #Ops    0
Test: many clients (4B many clients) (reliable network)...
  ... Passed --  time  3.5s #peers 5 #RPCs  2846 #Ops  757
Test: many clients (4B many clients) (unreliable network)...
  ... Passed --  time  4.0s #peers 5 #RPCs  1768 #Ops  289
Test: one client (4B progress in majority) (unreliable network)...
  ... Passed --  time  0.5s #peers 5 #RPCs   102 #Ops    3
Test: no progress in minority (4B) (unreliable network)...
  ... Passed --  time  1.1s #peers 5 #RPCs   313 #Ops    3
Test: completion after heal (4B) (unreliable network)...
  ... Passed --  time  1.1s #peers 5 #RPCs   126 #Ops    4
Test: partitions, one client (4B partitions, one client) (reliable network)...
  ... Passed --  time 10.5s #peers 5 #RPCs  3831 #Ops  535
Test: partitions, many clients (4B partitions, many clients (4B)) (reliable network)...
  ... Passed --  time  9.3s #peers 5 #RPCs  3401 #Ops  775
Test: restarts, one client (4B restarts, one client 4B ) (reliable network)...
  ... Passed --  time  6.1s #peers 5 #RPCs  3051 #Ops  493
Test: restarts, many clients (4B restarts, many clients) (reliable network)...
  ... Passed --  time  6.4s #peers 5 #RPCs  3553 #Ops  703
Test: restarts, many clients (4B restarts, many clients ) (unreliable network)...
  ... Passed --  time  7.0s #peers 5 #RPCs  1901 #Ops  215
Test: restarts, partitions, many clients (4B restarts, partitions, many clients) (reliable network)...
  ... Passed --  time 16.7s #peers 5 #RPCs  5241 #Ops  709
Test: restarts, partitions, many clients (4B restarts, partitions, many clients) (unreliable network)...
  ... Passed --  time 14.5s #peers 5 #RPCs  2990 #Ops  257
Test: restarts, partitions, random keys, many clients (4B restarts, partitions, random keys, many clients) (unreliable network)...
  ... Passed --  time 13.5s #peers 7 #RPCs  5210 #Ops  510
PASS
ok      6.5840/kvraft1  108.263s
```