### PR TITLE
[Lab4C]: Key/value service with snapshots 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@
 
     Your servers should not directly communicate; they should only interact with each other through Raft.
 
-    - **[Lab4A Code Change](https://github.com/mwfj/6.5840-Distributed-Systems/pull/13)**
+    - [**Lab4A Code Change**](https://github.com/mwfj/6.5840-Distributed-Systems/pull/13)
+    - [**Replicated State Machine README**](./src/kvraft1/rsm/README.md)
+
 
   - [x] Part B: Key/value service without snapshots: Now you will use the `rsm` package to replicate a key/value server. Each of the servers ("kvservers") will have an associated rsm/Raft peer. Clerks send `Put()` and `Get()` RPCs to the kvserver whose associated Raft is the leader. The kvserver code submits the Put/Get operation to `rsm`, which replicates it using Raft and invokes your server's `DoOp` at each peer, which should apply the operations to the peer's key/value database; the intent is for the servers to maintain identical replicas of the key/value database.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
     Snapshot(index int, snapshot []byte)
     ```
 
-- [ ] [6.5840 Lab 4: Fault-tolerant Key/Value Service](https://pdos.csail.mit.edu/6.824/labs/lab-kvraft1.html): In this lab you will build a fault-tolerant key/value storage service using your Raft library from [Lab 3](https://pdos.csail.mit.edu/6.824/labs/lab-raft1.html). To clients, the service looks similar to the server of [Lab 2](https://pdos.csail.mit.edu/6.824/labs/lab-kvsrv1.html). However, instead of a single server, the service consists of a set of servers that use Raft to help them maintain identical databases. Your key/value service should continue to process client requests as long as a majority of the servers are alive and can communicate, in spite of other failures or network partitions. After Lab 4, you will have implemented all parts (Clerk, Service, and Raft) shown in the [diagram of Raft interactions](https://pdos.csail.mit.edu/6.824/figs/kvraft.pdf).
+- [x] [**Lab 4: Fault-tolerant Key/Value Service**](https://pdos.csail.mit.edu/6.824/labs/lab-kvraft1.html): In this lab you will build a fault-tolerant key/value storage service using your Raft library from [Lab 3](https://pdos.csail.mit.edu/6.824/labs/lab-raft1.html). To clients, the service looks similar to the server of [Lab 2](https://pdos.csail.mit.edu/6.824/labs/lab-kvsrv1.html). However, instead of a single server, the service consists of a set of servers that use Raft to help them maintain identical databases. Your key/value service should continue to process client requests as long as a majority of the servers are alive and can communicate, in spite of other failures or network partitions. After Lab 4, you will have implemented all parts (Clerk, Service, and Raft) shown in the [diagram of Raft interactions](https://pdos.csail.mit.edu/6.824/figs/kvraft.pdf).
 
   Clients will interact with your key/value service through a Clerk, as in Lab 2. A Clerk implements the `Put` and `Get` methods with the same semantics as Lab 2: Puts are at-most-once and the Puts/Gets must form a linearizable history.
 
@@ -81,10 +81,11 @@
 
     Your kvservers should not directly communicate; they should only interact with each other through Raft.
 
-    - [**Lab 4B code change**](https://github.com/mwfj/6.5840-Distributed-Systems/pull/15)
+    - [**Lab 4B Code Change**](https://github.com/mwfj/6.5840-Distributed-Systems/pull/15)
 
-  - [ ] Part C: Key/value service with snapshots:  As things stand now, your key/value server doesn't call your Raft library's `Snapshot()` method, so a rebooting server has to replay the complete persisted Raft log in order to restore its state. Now you'll modify kvserver and `rsm` to cooperate with Raft to save log space and reduce restart time, using Raft's `Snapshot()` from Lab 3D.
+  - [x] Part C: Key/value service with snapshots:  As things stand now, your key/value server doesn't call your Raft library's `Snapshot()` method, so a rebooting server has to replay the complete persisted Raft log in order to restore its state. Now you'll modify kvserver and `rsm` to cooperate with Raft to save log space and reduce restart time, using Raft's `Snapshot()` from Lab 3D.
   
     The tester passes `maxraftstate` to your `StartKVServer()`, which passes it to `rsm`. `maxraftstate` indicates the maximum allowed size of your persistent Raft state in bytes (including the log, but not including snapshots). You should compare `maxraftstate` to `rf.PersistBytes()`. Whenever your `rsm` detects that the Raft state size is approaching this threshold, it should save a snapshot by calling Raft's `Snapshot`. `rsm` can create this snapshot by calling the `Snapshot` method of the `StateMachine` interface to obtain a snapshot of the kvserver. If `maxraftstate` is -1, you do not have to snapshot. The `maxraftstate` limit applies to the GOB-encoded bytes your Raft passes as the first argument to `persister.Save()`.
   
     You can find the source for the `persister` object in `tester1/persister.go`.
+    - [**Lab 4C Code Change**](https://github.com/mwfj/6.5840-Distributed-Systems/pull/16)

--- a/src/kvraft1/rsm/README.md
+++ b/src/kvraft1/rsm/README.md
@@ -1,0 +1,416 @@
+# Replicated State Machine (RSM) - Knowledge Background
+
+## Table of Contents
+- [Academic Foundation](#academic-foundation)
+- [Core Concepts](#core-concepts)
+- [Architectural Role](#architectural-role)
+- [Required Reading](#required-reading)
+- [Lab Learning Objectives](#lab-learning-objectives)
+- [Theoretical Properties](#theoretical-properties)
+- [Design Principles](#design-principles)
+- [References](#references)
+
+---
+
+## Academic Foundation
+
+### Primary Theory Source
+
+**Fred Schneider's Foundational Paper (1990)**
+- "Implementing Fault-Tolerant Services Using the State Machine Approach: A Tutorial"
+- Paper: https://pdos.csail.mit.edu/6.824/papers/schneider-rsm.pdf
+- This is THE fundamental paper on State Machine Replication
+- Originally described by Lamport (1978), elaborated by Schneider (1990)
+- **Core idea**: Deterministic state machines executing the same sequence of commands produce identical outputs
+
+### Course Context
+
+This RSM implementation is part of **MIT 6.5840/6.824 (Distributed Systems)**:
+- **Lab 4 Part A**: Fault-tolerant Key/Value Service
+- Lab instructions: https://pdos.csail.mit.edu/6.824/labs/lab-kvraft1.html
+- Builds on **Lab 3 (Raft)** consensus implementation
+- See [course diagram](https://pdos.csail.mit.edu/6.824/figs/kvraft.pdf) showing Clerk → Service → RSM → Raft layers
+
+---
+
+## Core Concepts
+
+### What is State Machine Replication?
+
+**Definition**: A technique for implementing fault-tolerant services by replicating servers and coordinating client interactions with server replicas.
+
+**Key Principle**:
+- Multiple servers independently implement the same deterministic state machine
+- All servers execute **the same sequence of commands** via consensus (Raft)
+- Results in **identical states and outputs** across all replicas
+- Provides **fault tolerance** - system continues despite server failures
+
+### The RSM-Consensus Relationship
+
+1. **Consensus** = Agreement on a single value by independent entities
+2. **State Machine Replication** = Running consensus repeatedly to agree on a sequence of commands
+3. **Consensus protocols (like Raft)** are used to implement SMR
+
+**Key Insight**: Consensus and State Machine Replication are generally considered equivalent problems, though completing an SMR command can be more expensive than solving a single consensus instance.
+
+### Deterministic State Machines
+
+For SMR to work correctly:
+- State machines must be **deterministic** (same input → same output)
+- All replicas must start from the same initial state
+- All replicas must execute commands in the **same order** (total ordering)
+- Non-deterministic operations (random numbers, timestamps) must be handled specially
+
+---
+
+## Architectural Role
+
+### Three-Layer Architecture
+
+The RSM sits as a middleware layer between the service and consensus:
+
+```
+Client/Clerk
+    ↓
+    [RPC calls: Get, Put, Append]
+    ↓
+Service Layer (Key/Value Database)
+    ↓ (implements StateMachine interface: DoOp, Snapshot, Restore)
+    ↓
+RSM Package ← Abstraction Layer
+    ↓ (uses Raft for consensus)
+    ↓
+Raft Consensus Layer
+    ↓ (maintains replicated log)
+    ↓
+Persistent Storage
+```
+
+### RSM Responsibilities
+
+1. **Abstracts Raft complexity** from the service layer
+   - Service doesn't need to understand Raft internals
+   - Clean interface through `Submit()` and `StateMachine`
+
+2. **Manages Submit/Apply interaction**:
+   - Service calls `rsm.Submit()` with operations
+   - RSM calls `raft.Start()` to propose to consensus
+   - Reader goroutine receives committed operations from `applyCh`
+   - Calls service's `DoOp()` to execute
+   - Returns result to waiting `Submit()` call
+
+3. **Handles edge cases**:
+   - Wrong leader detection → return `ErrWrongLeader`
+   - Leadership changes mid-operation → retry detection
+   - Operation deduplication via unique IDs
+   - Graceful shutdown coordination
+
+4. **Snapshot coordination**:
+   - Monitors Raft state size
+   - Triggers snapshots at threshold (90% of maxraftstate)
+   - Coordinates with service's snapshot/restore
+
+---
+
+## Required Reading
+
+### Primary References
+
+1. **[Extended Raft Paper](https://pdos.csail.mit.edu/6.824/papers/raft-extended.pdf)**
+   - Focus on Section 7 (Log Compaction)
+   - Describes snapshot mechanism
+   - InstallSnapshot RPC specification
+
+2. **[Schneider's RSM Tutorial](https://pdos.csail.mit.edu/6.824/papers/schneider-rsm.pdf)**
+   - Fundamental theory of state machine replication
+   - Properties and correctness conditions
+   - Implementation approaches
+
+3. **[Bolosky et al.](http://static.usenix.org/event/nsdi11/tech/full_papers/Bolosky.pdf)**
+   - Practical considerations for SMR systems
+   - Performance optimizations
+   - Real-world deployment lessons
+
+### Related Systems (for broader perspective)
+
+- **Chubby**: Google's lock service using Paxos
+- **Paxos Made Live**: Google's experience with Paxos
+- **Spanner**: Google's globally-distributed database
+- **Zookeeper**: Apache's coordination service
+- **Harp**: Replicated file system
+- **Viewstamped Replication**: Early consensus protocol
+
+---
+
+## Lab Learning Objectives
+
+### Part A Goals (RSM Implementation)
+
+From Lab 4 Part A instructions:
+
+1. **Implement reader goroutine**
+   - Reads from Raft's `applyCh` channel
+   - Processes committed commands
+   - Handles snapshot messages
+   - Runs continuously until shutdown
+
+2. **Implement Submit() function**:
+   - Wraps operations with unique IDs (`Op{Me, Id, Req}`)
+   - Calls `raft.Start()` to propose operation
+   - Waits for commit via pending operations map
+   - Returns result or `ErrWrongLeader`
+   - Handles timeouts appropriately
+
+3. **Handle tricky scenarios**:
+   - Leadership changes after `Start()` but before commit
+   - Operation lost/never committed (term change detection)
+   - Matching `applyCh` messages with waiting `Submit()` calls
+   - Concurrent operations from multiple clients
+   - Server crashes and restarts
+
+### Expected Operation Flow
+
+**Normal case (successful operation)**:
+
+```
+1. Client sends request → Service leader
+2. Service → rsm.Submit(request)
+3. rsm.Submit() → raft.Start(request) → WAIT
+4. Raft → commits → sends to all peers' applyCh
+5. RSM reader → reads applyCh → service.DoOp()
+6. Leader's reader → hands result to Submit() → returns to client
+```
+
+**Error cases**:
+- Not leader → return `ErrWrongLeader` immediately
+- Lost leadership → detect via term change, return `ErrWrongLeader`
+- Operation superseded → notify pending op, return error
+- Timeout → periodically check leadership status
+
+---
+
+## Theoretical Properties
+
+### Essential Properties for Correctness
+
+1. **Determinism**
+   - State machines must be deterministic (same input → same output)
+   - All replicas produce identical results given same command sequence
+   - Non-deterministic operations must be made deterministic (e.g., leader decides timestamp)
+
+2. **Total Ordering**
+   - All replicas execute commands in the same order
+   - Provided by Raft's replicated log
+   - Log index determines execution order
+
+3. **Fault Tolerance**
+   - System tolerates f failures with 2f+1 replicas
+   - Raft requires majority (quorum) for progress
+   - Example: 3 servers tolerate 1 failure, 5 servers tolerate 2 failures
+
+4. **Linearizability**
+   - Operations appear to execute atomically
+   - Operations appear in real-time order
+   - Once a client reads a value, it never reads an older value
+   - Achieved by waiting for commit before returning
+
+5. **At-Most-Once Semantics**
+   - Each operation committed and executed exactly once
+   - Duplicate detection via unique operation IDs
+   - Critical for operations with side effects (Put, Append)
+
+### Safety vs Liveness
+
+**Safety** (must always hold):
+- Never return incorrect results
+- Never violate linearizability
+- Never execute operation twice
+
+**Liveness** (should eventually happen):
+- Operations eventually complete (if majority alive)
+- May block during network partitions
+- May timeout and require retry
+
+---
+
+## Design Principles
+
+### Applied in This Implementation
+
+Based on `src/kvraft1/rsm/rsm.go`:
+
+#### 1. Operation Deduplication (lines 26-33)
+```go
+type Op struct {
+    Me  int   // server's request id
+    Id  int64 // unique id for each request
+    Req any   // request content
+}
+```
+- Unique `{Me, Id}` tuple per operation
+- Prevents duplicate execution
+- Allows matching committed ops with pending submissions
+
+#### 2. Pending Operations Tracking (lines 47-52, 63)
+```go
+type PendingOp struct {
+    op     Op
+    result any
+    done   chan bool
+}
+pendingOps map[int]*PendingOp  // index → PendingOp
+```
+- Maps log index to waiting operation
+- Enables notification when operation commits
+- Supports concurrent submissions
+
+#### 3. Linearizability via Wait (lines 125-163)
+```go
+func (rsm *RSM) Submit(req any) (rpc.Err, any) {
+    // ... create op, call raft.Start() ...
+    // Wait for commit before returning
+}
+```
+- Client waits for commit
+- Returns result only after execution
+- Ensures linearizable semantics
+
+#### 4. Snapshot Coordination (line 347-349)
+```go
+if rsm.maxraftstate > 0 && rsm.rf.PersistBytes() > (rsm.maxraftstate*9)/10 {
+    go rsm.createSnapshot(msg.CommandIndex)
+}
+```
+- Monitors Raft state size
+- Triggers at 90% threshold (not 100% to avoid overshoot)
+- Asynchronous snapshot creation
+
+#### 5. Graceful Shutdown (lines 131-162, 186-202)
+```go
+shutdown   atomic.Bool
+shutdownCh chan struct{}
+activeOps  sync.WaitGroup
+```
+- Coordinates cleanup across goroutines
+- Notifies pending operations
+- Prevents deadlocks during shutdown
+
+#### 6. Wrong Leader Detection (lines 252-294)
+```go
+func (rsm *RSM) waitForResult(pendingOp *PendingOp, initialTerm int) {
+    // Periodically check term/leadership
+    // Return ErrWrongLeader if changed
+}
+```
+- Periodic leadership checks
+- Term change detection
+- Timeout mechanism
+
+---
+
+## Implementation Challenges
+
+### Common Pitfalls
+
+1. **Matching operations to results**
+   - Challenge: Multiple concurrent operations, log indices may be reused
+   - Solution: Use unique operation IDs, check term matches
+
+2. **Leadership changes**
+   - Challenge: Operation proposed but leadership lost before commit
+   - Solution: Detect term changes, notify pending operations to retry
+
+3. **Duplicate execution**
+   - Challenge: Same operation might appear multiple times
+   - Solution: Track executed operation IDs, skip duplicates
+
+4. **Snapshot timing**
+   - Challenge: When to snapshot? Too early wastes space, too late risks overflow
+   - Solution: Trigger at 90% threshold asynchronously
+
+5. **Shutdown coordination**
+   - Challenge: Multiple goroutines need to terminate cleanly
+   - Solution: Shutdown channel, atomic flags, WaitGroups
+
+6. **Stale reads**
+   - Challenge: Followers might have outdated state
+   - Solution: All operations go through leader via Raft
+
+---
+
+## Testing Strategy
+
+### Test Coverage (from `rsm_test.go`)
+
+1. **TestBasic4A**: Basic functionality
+   - Sequential operations
+   - State verification across replicas
+
+2. **TestConcurrent4A**: Concurrent submissions
+   - Many concurrent operations
+   - Correctness under load
+
+3. **TestLeaderFailure4A**: Leader failure handling
+   - Disconnect leader
+   - New leader election
+   - Old leader catch-up
+
+4. **TestLeaderPartition4A**: Minority can't commit
+   - Network partitions
+   - Majority/minority behavior
+   - Partition healing
+
+5. **TestRestartReplay4A**: Persistence & replay
+   - Full system shutdown/restart
+   - State preservation via persistence
+
+6. **TestShutdown4A**: Graceful shutdown
+   - Pending operations during shutdown
+   - Clean termination without deadlocks
+
+7. **TestRestartSubmit4A**: Complex restart scenarios
+   - Multiple shutdown/restart cycles
+   - Pending ops across restarts
+
+8. **TestSnapshot4C**: Snapshotting
+   - Log compaction verification
+   - Snapshot restore correctness
+   - Size limits enforced
+
+---
+
+## References
+
+### Academic Papers
+- [State machine replication - Wikipedia](https://en.wikipedia.org/wiki/State_machine_replication)
+- [Schneider RSM Paper](https://pdos.csail.mit.edu/6.824/papers/schneider-rsm.pdf)
+- [Extended Raft Paper](https://pdos.csail.mit.edu/6.824/papers/raft-extended.pdf)
+- [Consensus for State Machine Replication](https://decentralizedthoughts.github.io/2019-10-15-consensus-for-state-machine-replication/)
+
+### Course Materials
+- [MIT 6.5840/6.824 Course](https://pdos.csail.mit.edu/6.824/)
+- [Lab 4: Fault-tolerant Key/Value Service](https://pdos.csail.mit.edu/6.824/labs/lab-kvraft1.html)
+- [KVRaft Diagram](https://pdos.csail.mit.edu/6.824/figs/kvraft.pdf)
+- [6.824 Lab 7: Replicated State Machine](https://pdos.csail.mit.edu/archive/6.824-2012/labs/lab-7.html)
+
+### Additional Resources
+- [Lab 3: Raft Implementation](http://nil.csail.mit.edu/6.824/2022/labs/lab-kvraft.html)
+- [Tutorial on SMR](https://www.di.fc.ul.pt/~bessani/publications/tutorial-smr.pdf)
+
+---
+
+## Summary
+
+**Replicated State Machine (RSM)** is a fundamental distributed systems pattern that provides:
+- **Fault tolerance** through replication
+- **Strong consistency** via consensus (Raft)
+- **Linearizability** for client operations
+- **Clean abstraction** between service logic and consensus
+
+The implementation in `src/kvraft1/rsm/` demonstrates:
+- Proper interaction with Raft consensus
+- Handling of concurrent operations
+- Snapshot coordination for log compaction
+- Graceful error handling and recovery
+
+This forms the foundation for building fault-tolerant distributed services like replicated key-value stores, configuration services, and distributed databases.

--- a/src/kvraft1/rsm/rsm.go
+++ b/src/kvraft1/rsm/rsm.go
@@ -378,9 +378,9 @@ func (rsm *RSM) createSnapshot(index int) {
 	// we create a snapshot for the current state
 	snapshotIndex := rsm.lastApplied
 
-	// CRITICAL: Never lie about snapshot index!
+	// CRITICAL: Never lie about snapshot index! That's the tricky point for unit test
 	// If lastApplied < requested index, it means we haven't applied enough operations yet.
-	// We should snapshot at the current lastApplied, not the requested index.
+	// In that case, we should snapshot at the current lastApplied, not the requested index.
 	// Using a higher index than our actual state would cause operations to be lost on restore!
 	if snapshotIndex < index {
 		// This can happen if createSnapshot is called before the operation is applied

--- a/src/kvraft1/rsm/rsm.go
+++ b/src/kvraft1/rsm/rsm.go
@@ -2,6 +2,7 @@ package rsm
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -59,11 +60,12 @@ type RSM struct {
 	maxraftstate int // snapshot if log grows this big
 	sm           StateMachine
 	// Your definitions here.
-	opId       int64              // the unique operation id
-	pendingOps map[int]*PendingOp // persist the operation that not finished
-	shutdown   atomic.Bool
-	shutdownCh chan struct{}  // used to signal shutdown to all waiting operations
-	activeOps  sync.WaitGroup // track active Submit operations
+	opId        int64              // the unique operation id
+	lastApplied int                // last applied Raft log index
+	pendingOps  map[int]*PendingOp // persist the operation that not finished
+	shutdown    atomic.Bool
+	shutdownCh  chan struct{}  // used to signal shutdown to all waiting operations
+	activeOps   sync.WaitGroup // track active Submit operations
 }
 
 // servers[] contains the ports of the set of
@@ -88,6 +90,7 @@ func MakeRSM(servers []*labrpc.ClientEnd, me int, persister *tester.Persister, m
 		applyCh:      make(chan raftapi.ApplyMsg),
 		sm:           sm,
 		opId:         0,
+		lastApplied:  0,
 		pendingOps:   make(map[int]*PendingOp),
 		shutdownCh:   make(chan struct{}),
 	}
@@ -103,11 +106,14 @@ func MakeRSM(servers []*labrpc.ClientEnd, me int, persister *tester.Persister, m
 			r := bytes.NewBuffer(snapshot)
 			d := labgob.NewDecoder(r)
 			var opId int64
+			var lastApplied int
 			var smSnapshot []byte
-			if d.Decode(&opId) != nil || d.Decode(&smSnapshot) != nil {
+			if d.Decode(&opId) != nil || d.Decode(&lastApplied) != nil || d.Decode(&smSnapshot) != nil {
 				panic("Failed to decode from snapshot")
 			}
 			atomic.StoreInt64(&rsm.opId, opId)
+			// Set lastApplied from snapshot so we know not to re-apply those operations
+			rsm.lastApplied = lastApplied
 			rsm.sm.Restore(smSnapshot)
 		}
 	}
@@ -326,7 +332,15 @@ func (rsm *RSM) applyCommand(msg raftapi.ApplyMsg) {
 	}
 	rsm.mu.Lock()
 
+	// Only apply if this is a new command (prevents re-applying after snapshot restore)
+	if msg.CommandIndex <= rsm.lastApplied {
+		rsm.mu.Unlock()
+		return
+	}
+
 	result := rsm.sm.DoOp(op.Req)
+	rsm.lastApplied = msg.CommandIndex
+
 	if pendingOp, exists := rsm.pendingOps[msg.CommandIndex]; exists {
 		if pendingOp.op.Id == op.Id && pendingOp.op.Me == rsm.me {
 			pendingOp.result = result
@@ -342,10 +356,14 @@ func (rsm *RSM) applyCommand(msg raftapi.ApplyMsg) {
 			}
 		}
 	}
+	shouldSnapshot := rsm.maxraftstate > 0 && rsm.rf.PersistBytes() > (rsm.maxraftstate*9)/10
+	snapshotIndex := msg.CommandIndex
+
 	rsm.mu.Unlock()
 
-	if rsm.maxraftstate > 0 && rsm.rf.PersistBytes() > (rsm.maxraftstate*9)/10 {
-		go rsm.createSnapshot(msg.CommandIndex)
+	// Create snapshot outside the lock to avoid blocking other operations
+	if shouldSnapshot {
+		rsm.createSnapshot(snapshotIndex)
 	}
 
 }
@@ -353,32 +371,61 @@ func (rsm *RSM) applyCommand(msg raftapi.ApplyMsg) {
 func (rsm *RSM) createSnapshot(index int) {
 	rsm.mu.Lock()
 	defer rsm.mu.Unlock()
+
+	// Always use rsm.lastApplied as the snapshot index
+	// This ensures the snapshot data matches the index we report to Raft
+	// Even if more commands were applied after we decided to snapshot,
+	// we create a snapshot for the current state
+	snapshotIndex := rsm.lastApplied
+
+	// Sanity check: snapshot index should be at least as high as requested
+	if snapshotIndex < index {
+		// This shouldn't happen, but if it does, use the requested index
+		snapshotIndex = index
+	}
+
 	w := new(bytes.Buffer)
 	e := labgob.NewEncoder(w)
 	opId := atomic.LoadInt64(&rsm.opId)
 	smSnapshot := rsm.sm.Snapshot()
+
 	e.Encode(opId)
+	e.Encode(snapshotIndex)
 	e.Encode(smSnapshot)
-	rsm.rf.Snapshot(index, w.Bytes())
+
+	rsm.rf.Snapshot(snapshotIndex, w.Bytes())
 }
 
 func (rsm *RSM) applySnapshot(msg raftapi.ApplyMsg) {
 	rsm.mu.Lock()
 	defer rsm.mu.Unlock()
 
+	// Only apply snapshot if it's newer than what we've already applied
+	// This prevents rolling back to an older state
+	if msg.SnapshotIndex <= rsm.lastApplied {
+		return
+	}
+
 	r := bytes.NewBuffer(msg.Snapshot)
 	d := labgob.NewDecoder(r)
 	var opId int64
+	var snapshotIndex int
 	var smSnapshot []byte
-	if d.Decode(&opId) != nil || d.Decode(&smSnapshot) != nil {
+	if d.Decode(&opId) != nil || d.Decode(&snapshotIndex) != nil || d.Decode(&smSnapshot) != nil {
 		panic("Failed to decode from snapshot")
 	}
-	currentOpId := atomic.LoadInt64(&rsm.opId)
-	if opId > currentOpId {
-		atomic.StoreInt64(&rsm.opId, opId)
+
+	// Verify the snapshot index matches what Raft told us
+	if snapshotIndex != msg.SnapshotIndex {
+		panic(fmt.Sprintf("Snapshot index mismatch: encoded=%d, msg=%d", snapshotIndex, msg.SnapshotIndex))
 	}
+
+	// Restore the snapshot
+	atomic.StoreInt64(&rsm.opId, opId)
+	rsm.lastApplied = msg.SnapshotIndex
 	rsm.sm.Restore(smSnapshot)
 
+	// Notify pending operations that are covered by this snapshot
 	for index, pendingOp := range rsm.pendingOps {
 		if index <= msg.SnapshotIndex {
 			select {

--- a/src/kvraft1/server.go
+++ b/src/kvraft1/server.go
@@ -102,11 +102,6 @@ func (kv *KVServer) DoOp(req any) any {
 			replyMsg.Version = kvPair.Version
 			replyMsg.Err = rpc.OK
 		} else {
-			// Debug: Log when we return ErrNoKey for investigation
-			if raftReq.Key == "k45" || len(kv.cache) < 5 {
-				// Log details about the missing key
-				_ = raftReq.ClientId // Keep for debugging
-			}
 			replyMsg.Err = rpc.ErrNoKey
 		}
 

--- a/src/kvsrv1/client.go
+++ b/src/kvsrv1/client.go
@@ -1,8 +1,7 @@
 package kvsrv
 
 import (
-	"math/rand"
-	"time"
+	"sync/atomic"
 
 	"6.5840/kvsrv1/rpc"
 	kvtest "6.5840/kvtest1"
@@ -16,11 +15,15 @@ type Clerk struct {
 	seqNum   int64
 }
 
+var globalClientId int64
+
 func MakeClerk(clnt *tester.Clnt, server string) kvtest.IKVClerk {
 	ck := &Clerk{
-		clnt:     clnt,
-		server:   server,
-		clientId: rand.New(rand.NewSource(time.Now().UnixNano())).Int63(),
+		clnt:   clnt,
+		server: server,
+		// Use a monotonically increasing ID to avoid collisions when many
+		// clerks are created concurrently.
+		clientId: atomic.AddInt64(&globalClientId, 1),
 		seqNum:   0,
 	}
 	// You may add code here.

--- a/src/raft1/README.md
+++ b/src/raft1/README.md
@@ -65,6 +65,8 @@ Implement Snapshot(Log compact) in Raft.
 
 ## Test Result
 
+Note on timeouts: `-race` can slow the suite down significantly, and `-count=2` doubles it again. If you run the full suite with `go test -race -run . -count=2`, you may hit Go's default `-timeout 10m` and see a goroutine dump that looks like a hang. Use a larger timeout, e.g. `go test -race -run . -count=2 -timeout 60m`.
+
 ### **Lab 3A**
 
 ```shell
@@ -156,4 +158,3 @@ Test (3D): snapshot initialization after crash ...
 PASS
 ok      6.5840/raft     153.941s
 ```
-

--- a/src/raft1/raft.go
+++ b/src/raft1/raft.go
@@ -483,7 +483,10 @@ func (rf *Raft) AppendEntry(args *AppendEntryArgs, reply *AppendEntryReply) {
 	// §5.3: reply false if log doesn't contain an entry at prevLogIndex
 	//       whose term matches preLogTerm
 	if args.PrevLogIndex < rf.getFirstLog().Index {
+		// Leader is behind our snapshot; tell it to send a snapshot.
 		reply.Term, reply.Success = rf.rejectAppendEntry()
+		reply.ConflictIndex = rf.getFirstLog().Index
+		reply.ConflictTerm = -1
 		return
 	}
 
@@ -777,8 +780,6 @@ func (rf *Raft) doSendAppendEntry(peer int) {
 	}
 
 }
-
-// ---------------------------------------------------------------------------------------------------------------------
 
 func (rf *Raft) getLatestLog() LogEntry {
 	return rf.logs[len(rf.logs)-1]


### PR DESCRIPTION
Finished Lab4 partC: Implementation Key/value service with snapshots.

```shell
mwfj➜6.5840-Distributed-Systems/src/kvraft1(lab4-PartC-2025-ver✗)» go test -run . -race -timeout 1h
Test: one client (4B basic) (reliable network)...
labgob warning: Decoding into a non-default variable/field Err may not work
  ... Passed --  time  3.1s #peers 5 #RPCs  2911 #Ops  519
Test: one client (4B speed) (reliable network)...
  ... Passed --  time  9.7s #peers 3 #RPCs  3420 #Ops    0
Test: many clients (4B many clients) (reliable network)...
  ... Passed --  time  3.5s #peers 5 #RPCs  2835 #Ops  763
Test: many clients (4B many clients) (unreliable network)...
  ... Passed --  time  4.5s #peers 5 #RPCs  1962 #Ops  315
Test: one client (4B progress in majority) (unreliable network)...
  ... Passed --  time  0.7s #peers 5 #RPCs   140 #Ops    3
Test: no progress in minority (4B) (unreliable network)...
  ... Passed --  time  1.2s #peers 5 #RPCs   322 #Ops    3
Test: completion after heal (4B) (unreliable network)...
  ... Passed --  time  1.0s #peers 5 #RPCs   128 #Ops    4
Test: partitions, one client (4B partitions, one client) (reliable network)...
  ... Passed --  time  9.3s #peers 5 #RPCs  3578 #Ops  523
Test: partitions, many clients (4B partitions, many clients (4B)) (reliable network)...
  ... Passed --  time 10.5s #peers 5 #RPCs  3786 #Ops  765
Test: restarts, one client (4B restarts, one client 4B ) (reliable network)...
  ... Passed --  time  6.1s #peers 5 #RPCs  2975 #Ops  491
Test: restarts, many clients (4B restarts, many clients) (reliable network)...
  ... Passed --  time  6.5s #peers 5 #RPCs  3634 #Ops  703
Test: restarts, many clients (4B restarts, many clients ) (unreliable network)...
  ... Passed --  time  6.8s #peers 5 #RPCs  1795 #Ops  255
Test: restarts, partitions, many clients (4B restarts, partitions, many clients) (reliable network)...
  ... Passed --  time 16.0s #peers 5 #RPCs  4975 #Ops  717
Test: restarts, partitions, many clients (4B restarts, partitions, many clients) (unreliable network)...
  ... Passed --  time 13.5s #peers 5 #RPCs  2717 #Ops  253
Test: restarts, partitions, random keys, many clients (4B restarts, partitions, random keys, many clients) (unreliable network)...
  ... Passed --  time 13.4s #peers 7 #RPCs  5005 #Ops  520
Test: snapshots, one client (4C SnapshotsRPC) (reliable network)...
Test: InstallSnapshot RPC (4C) (reliable network)...
  ... Passed --  time  1.4s #peers 3 #RPCs   259 #Ops   63
Test: snapshots, one client (4C snapshot size is reasonable) (reliable network)...
  ... Passed --  time  0.8s #peers 3 #RPCs  2492 #Ops  800
Test: snapshots, one client (4C speed) (reliable network)...
  ... Passed --  time  0.9s #peers 3 #RPCs  3079 #Ops    0
Test: restarts, snapshots, one client (4C restarts, snapshots, one client) (reliable network)...
  ... Passed --  time  6.0s #peers 5 #RPCs 17152 #Ops 3329
Test: restarts, snapshots, many clients (4C restarts, snapshots, many clients ) (reliable network)...
info: linearizability check timed out, assuming history is ok
info: linearizability check timed out, assuming history is ok
info: linearizability check timed out, assuming history is ok
  ... Passed --  time 14.6s #peers 5 #RPCs 16755 #Ops 2899
Test: snapshots, many clients (4C unreliable net, snapshots, many clients) (unreliable network)...
  ... Passed --  time  3.9s #peers 5 #RPCs  1893 #Ops  275
Test: restarts, snapshots, many clients (4C unreliable net, restarts, snapshots, many clients) (unreliable network)...
  ... Passed --  time  6.9s #peers 5 #RPCs  1940 #Ops  275
Test: restarts, partitions, snapshots, many clients (4C unreliable net, restarts, partitions, snapshots, many clients) (unreliable network)...
  ... Passed --  time 12.3s #peers 5 #RPCs  2548 #Ops  241
Test: restarts, partitions, snapshots, random keys, many clients (4C unreliable net, restarts, partitions, snapshots, random keys, many clients) (unreliable network)...
  ... Passed --  time 14.4s #peers 7 #RPCs  5977 #Ops  598
PASS
ok      6.5840/kvraft1  168.188s
Test: one client (4B basic) (reliable network)...
mwfj➜6.5840-Distributed-Systems/src/kvraft1(lab4-PartC-2025-ver✗)» cd rsm
mwfj➜src/kvraft1/rsm(lab4-PartC-2025-ver✗)» go test -run . -race -timeout 1h
Test RSM basic (reliable network)...
  ... Passed --  time  0.7s #peers 3 #RPCs    44 #Ops    0
Test concurrent submit (reliable network)...
  ... Passed --  time  0.2s #peers 3 #RPCs    10 #Ops    0
Test Leader Failure (reliable network)...
  ... Passed --  time  0.5s #peers 3 #RPCs    29 #Ops    0
Test Leader Partition (reliable network)...
  ... Passed --  time  1.7s #peers 3 #RPCs   180 #Ops    0
Test Restart (reliable network)...
  ... Passed --  time  7.4s #peers 3 #RPCs   460 #Ops    0
Test Shutdown (reliable network)...
  ... Passed --  time 10.0s #peers 3 #RPCs     0 #Ops    0
Test Restart and submit (reliable network)...
  ... Passed --  time 17.7s #peers 3 #RPCs   476 #Ops    0
Test creating and restoring snapshot (reliable network)...
  ... Passed --  time  0.6s #peers 3 #RPCs   222 #Ops    0
PASS
ok      6.5840/kvraft1/rsm      39.926s
```